### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/dashboard/core/auth.py
+++ b/dashboard/core/auth.py
@@ -1,27 +1,18 @@
-import hashlib
-import secrets
-from typing import Tuple, Union
+from argon2 import PasswordHasher
 
 
-def create_salt(n: int = 6) -> str:
-    """Create a random string of length n."""
-    return secrets.token_hex(n)
+# Removed custom create_salt, now handled by argon2 internally
+
+ph = PasswordHasher()
+
+def hash_password(password: str) -> str:
+    """Hash a password using Argon2."""
+    return ph.hash(password)
 
 
-def hash_password(
-    password: str, salt: Union[str, None] = None, n: int = 50
-) -> Tuple[str, str]:
-    """Hash a password with a salt."""
-
-    # Create a salt if none is provided
-    if salt is None:
-        salt = create_salt()
-    # Hash the password with the salt
-    for _ in range(n):  # n rounds of hashing
-        password = hashlib.sha512((password + salt).encode("utf-8")).hexdigest()
-    return password, salt
-
-
-def check_password(password: str, hashed_password: str, salt: str) -> bool:
-    """Check if a password is correct."""
-    return hash_password(password, salt)[0] == hashed_password
+def check_password(password: str, hashed_password: str) -> bool:
+    """Check if a password is correct using Argon2."""
+    try:
+        return ph.verify(hashed_password, password)
+    except Exception:
+        return False

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,4 +1,5 @@
 altair==5.4.1 ; python_version >= "3.10" and python_version < "4.0" \
+argon2-cffi==25.1.0
     --hash=sha256:0ce8c2e66546cb327e5f2d7572ec0e7c6feece816203215613962f0ec1d76a82 \
     --hash=sha256:0fb130b8297a569d08991fb6fe763582e7569f8a04643bbd9212436e3be04aef
 annotated-types==0.7.0 ; python_version >= "3.10" and python_version < "4.0" \


### PR DESCRIPTION
Potential fix for [https://github.com/centille/Newsful/security/code-scanning/1](https://github.com/centille/Newsful/security/code-scanning/1)

To properly fix this, the password hashing should be replaced with a proper password hashing algorithm. The most recommended modern option in Python is Argon2, because of its strong memory-hard design, wide support, and the fact that it handles salt securely. Alternatively, `bcrypt` or `PBKDF2` are acceptable for compatibility reasons.

Here's the fix plan:
- Replace the custom SHA-512 and salt logic with `argon2-cffi`'s `PasswordHasher`, which manages salt and work factors securely.
- The `hash_password` function should use `PasswordHasher.hash(password)` and return the resulting hash.
- The `check_password` function should use `PasswordHasher.verify(stored_hash, password)`, since Argon2 encodes all necessary info (salt, params) in `stored_hash`.
- You no longer need to manage salt or number of rounds manually.
- Add required import for `argon2.PasswordHasher`.
- Update docstrings and function signatures accordingly.
- Remove the now-unneeded `create_salt`.

**Edits must be limited to the snippet shown** in `dashboard/core/auth.py`. Only add imports as necessary for `argon2-cffi`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
